### PR TITLE
[Issue_44] Renew suppressions for false positives that are still occu…

### DIFF
--- a/owasp-suppressions/owasp-suppressions.xml
+++ b/owasp-suppressions/owasp-suppressions.xml
@@ -226,7 +226,7 @@
       <packageUrl regex="true">^pkg:maven/org\.apache\.mina/mina\-core@.*$</packageUrl>
       <cve>CVE-2021-41973</cve>
    </suppress>
-   <suppress until="2026-03-11">
+   <suppress until="2027-03-26">
       <notes><![CDATA[
       file name: h2-2.2.224.jar
       ]]></notes>
@@ -234,7 +234,7 @@
       <!-- Disputed by h2database https://github.com/h2database/h2database/issues/1294 -->
       <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
    </suppress>
-   <suppress until="2026-03-11">
+   <suppress until="2027-03-26">
       <notes><![CDATA[
       file name: jakarta.security.enterprise-3.0.3.jar
       ]]></notes>
@@ -256,7 +256,7 @@
       <cve>CVE-2024-25710</cve>
       <cve>CVE-2024-26308</cve>
    </suppress>
-   <suppress until="2026-03-11">
+   <suppress until="2027-03-26">
       <notes><![CDATA[
       file name: resteasy-spring-3.0.4.Final.jar
       ]]></notes>
@@ -269,7 +269,7 @@
       <cve>CVE-2020-25633</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
       <cve>CVE-2021-20289</cve> <!-- CVE within Rest Easy not RestEasy Spring -->
    </suppress>
-   <suppress until="2026-03-11">
+   <suppress until="2027-03-26">
       <notes><![CDATA[
       file name: resteasy-tracing-api-2.0.1.Final.jar
       ]]></notes>
@@ -282,21 +282,21 @@
       <cve>CVE-2011-5245</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
       <cve>CVE-2012-0818</cve> <!-- CVE within Rest Easy not RestEasy Tracing API -->
    </suppress>
-   <suppress until="2026-03-11">
+   <suppress until="2027-03-26">
       <notes><![CDATA[
       file name: undertow-core-2.3.12.Final.jar
       ]]></notes>
       <packageUrl regex="true">^pkg:maven/io\.undertow/undertow\-core@.*$</packageUrl>
       <vulnerabilityName>CVE-2016-6311</vulnerabilityName>
    </suppress>
-   <suppress until="2026-03-11">
+   <suppress until="2027-03-26">
       <notes><![CDATA[
       file name: resteasy-spring-3.0.4.Final.jar
       ]]></notes>
       <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy\.spring/resteasy\-spring@.*$</packageUrl>
       <cve>CVE-2021-20293</cve>
    </suppress>
-   <suppress until="2026-03-11">
+   <suppress until="2027-03-26">
       <notes><![CDATA[
       file name: resteasy-tracing-api-2.0.1.Final.jar
       ]]></notes>


### PR DESCRIPTION
…rring for main and 39.0.1

Resolves #44 

TBH, as I did this I thought it could be better, but I don't have time today. If a reviewer thinks this PR should do any of these let me know  and maybe I will have time. This PR is currently focused on cleaning up results for main and 39.0.1.

1) For resteasy-spring and resteasy-tracing there are two suppression blocks each that are basically identical and could be combined.
2) For each of those two, the bigger suppression block lists 7 CVEs, but at least against main and 39.0.1 only 2 are currently producing false positives. So, we could check the results for the older versions and if none of the other CVEs are triggering positives we could trim those from the suppressions.
3) This PR re-enables some expressions that expired March 11. There are others that expired that day that it doesn't re-enable because there were no false positives against main or 39.0.1. We should check if any of the other version scans are now getting false positives related to those, and if yes, renew the suppression, and if no, remove the suppression.