### PR TITLE
Fix Issue 17: Allow skipping maintenance scanning when MAINTENANCE_CI is OFF

### DIFF
--- a/.github/workflows/scan-wildfly.yaml
+++ b/.github/workflows/scan-wildfly.yaml
@@ -13,6 +13,7 @@ jobs:
   scan-matrix:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/wildfly-nightly.yaml
+++ b/.github/workflows/wildfly-nightly.yaml
@@ -13,6 +13,7 @@ jobs:
   provision-matrix:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    if: ${{ matrix.version != 'maintenance' || vars.MAINTENANCE_CI != 'OFF' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add job-level conditionals to both maintenance workflows to gracefully skip maintenance builds when the MAINTENANCE_CI variable is set to "OFF".

Changes:
- wildfly-nightly.yaml: Skip maintenance matrix job when MAINTENANCE_CI == "OFF"
- scan-wildfly.yaml: Skip maintenance scan jobs when MAINTENANCE_CI == "OFF"

This prevents workflow failures when there is no active maintenance branch, while continuing to provision and scan upstream builds normally.