### PR TITLE
Fix: Use step-level conditionals instead of job-level

### DIFF
--- a/.github/workflows/scan-wildfly.yaml
+++ b/.github/workflows/scan-wildfly.yaml
@@ -13,7 +13,6 @@ jobs:
   scan-matrix:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
     strategy:
       max-parallel: 1
       matrix:
@@ -25,6 +24,7 @@ jobs:
 
       # Cache the instllation
       - name: Cache WildFly Installation
+        if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
         id: wildfly-cache
         uses: actions/cache/restore@v4
         with:
@@ -35,6 +35,7 @@ jobs:
 
       # Restore Dependency Check CLI from Cache
       - name: Cache Dependency Check Installation
+        if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
         id: dependency-check-cli-installation
         uses: actions/cache/restore@v4
         with:
@@ -48,6 +49,7 @@ jobs:
       # using the key, instead we restore the most recent and save
       # using the unique key.
       - name: Cache Dependency Check Database
+        if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
         id: cache-database
         uses: actions/cache@v4
         with:
@@ -57,6 +59,7 @@ jobs:
 
       # Populate a properties file with secrets
       - name: Populate Dependency Check Properties
+        if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
         run: |
           echo "analyzer.ossindex.password=${{ secrets.OSS_INDEX_PASSWORD }}" > dependency-check.properties
           ls -l
@@ -64,11 +67,12 @@ jobs:
 
       # Perform SCA Scan
       - name: Perform SCA Scan
+        if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
         run: ./dependency-check/bin/dependency-check.sh --project="WildFly ${{ matrix.version}}" --scan="wildfly" --noupdate --suppression=owasp-suppressions/owasp-suppressions.xml --data=owasp-database --format=HTML --format=JSON --nvdApiKey=${{ secrets.NVD_API_KEY }} --ossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} --propertyfile=dependency-check.properties --log=dependency-check.log
 
       # Upload the log files
       - name: Upload Scan Results
-        if: success()
+        if: ${{ success() && (!contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF') }}
         uses: actions/upload-artifact@v4
         with:
           name: scan-results-${{ matrix.version }}
@@ -76,7 +80,7 @@ jobs:
 
       # Upload the log files
       - name: Upload Log File
-        if: failure()
+        if: ${{ failure() && (!contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF') }}
         uses: actions/upload-artifact@v4
         with:
           name: log-files-${{ matrix.version }}

--- a/.github/workflows/wildfly-nightly.yaml
+++ b/.github/workflows/wildfly-nightly.yaml
@@ -13,7 +13,6 @@ jobs:
   provision-matrix:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    if: ${{ matrix.version != 'maintenance' || vars.MAINTENANCE_CI != 'OFF' }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +35,7 @@ jobs:
       # we map to the job name as seen in ci.wildfly.org
 
       - name: Map version to nightly name in CI
+        if: ${{ matrix.version != 'maintenance' || vars.MAINTENANCE_CI != 'OFF' }}
         id: version-map
         run: |
           VERSION_NAME=${{ matrix.version}}
@@ -49,16 +49,19 @@ jobs:
           fi
 
       - name: Download Nightly Build
+        if: ${{ matrix.version != 'maintenance' || vars.MAINTENANCE_CI != 'OFF' }}
         id: wildfly-nightly
         uses: wildfly-extras/wildfly-nightly-download@v1
         with:
           uri: https://ci.wildfly.org/guestAuth/repository/download/${{ steps.version-map.outputs.CI_JOB }}/latest.lastSuccessful/wildfly-maven-repository.tar.gz
 
       - name: Provision WildFly
+        if: ${{ matrix.version != 'maintenance' || vars.MAINTENANCE_CI != 'OFF' }}
         run: " ./galleon/bin/galleon.sh install wildfly#${{ steps.wildfly-nightly.outputs.wildfly-version }} --dir=wildfly"
 
       # Cache the installation
       - name: Cache WildFly Installation
+        if: ${{ matrix.version != 'maintenance' || vars.MAINTENANCE_CI != 'OFF' }}
         id: wildfly-cache
         uses: actions/cache/save@v4
         with:
@@ -66,12 +69,14 @@ jobs:
           key: wildfly-standard-${{ matrix.version}}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Provision WildFly Preview
+        if: ${{ matrix.version != 'maintenance' || vars.MAINTENANCE_CI != 'OFF' }}
         run: |
           rm -fR ${{ github.workspace }}/wildfly
           ./galleon/bin/galleon.sh install wildfly-preview#${{ steps.wildfly-nightly.outputs.wildfly-version }} --dir=wildfly
 
       # Cache the installation
       - name: Cache WildFly Preview Installation
+        if: ${{ matrix.version != 'maintenance' || vars.MAINTENANCE_CI != 'OFF' }}
         id: wildfly-preview-cache
         uses: actions/cache/save@v4
         with:


### PR DESCRIPTION
The previous commit attempted to use job-level if conditions, but the matrix context is not available at the job level in GitHub Actions.

This commit corrects the approach by:
- Adding if conditions to each step that should be skipped
- wildfly-nightly.yaml: 6 steps check matrix.version != 'maintenance'
- scan-wildfly.yaml: 7 steps check !contains(matrix.version, 'maintenance')

All steps skip when version is maintenance AND MAINTENANCE_CI == 'OFF'.