### PR TITLE
Resolves #61 - Add SONATYPE_OSS_INDEX variable to toggle OSS Index scanning on/off

### DIFF
--- a/.github/workflows/database-maintenance.yaml
+++ b/.github/workflows/database-maintenance.yaml
@@ -47,13 +47,22 @@ jobs:
       # Populate a properties file with secrets
       - name: Populate Dependency Check Properties
         run: |
-          echo "analyzer.ossindex.password=${{ secrets.OSS_INDEX_PASSWORD }}" > dependency-check.properties
+          if [ "${{ vars.SONATYPE_OSS_INDEX }}" == "OFF" ]; then
+            echo "analyzer.ossindex.enabled=false" > dependency-check.properties
+          else
+            echo "analyzer.ossindex.password=${{ secrets.OSS_INDEX_PASSWORD }}" > dependency-check.properties
+          fi
           ls -l
           cat dependency-check.properties
 
       # Update Database
       - name: Update OWASP Database
-        run: ./dependency-check/bin/dependency-check.sh --updateonly --data=owasp-database --nvdApiKey=${{ secrets.NVD_API_KEY }} --ossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} --propertyfile=dependency-check.properties --log=dependency-check.log
+        run: |
+          OSS_ARGS=""
+          if [ "${{ vars.SONATYPE_OSS_INDEX }}" != "OFF" ]; then
+            OSS_ARGS="--ossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }}"
+          fi
+          ./dependency-check/bin/dependency-check.sh --updateonly --data=owasp-database --nvdApiKey=${{ secrets.NVD_API_KEY }} $OSS_ARGS --propertyfile=dependency-check.properties --log=dependency-check.log
 
       # Upload the log files
       - name: Upload Log File

--- a/.github/workflows/scan-wildfly.yaml
+++ b/.github/workflows/scan-wildfly.yaml
@@ -61,14 +61,23 @@ jobs:
       - name: Populate Dependency Check Properties
         if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
         run: |
-          echo "analyzer.ossindex.password=${{ secrets.OSS_INDEX_PASSWORD }}" > dependency-check.properties
+          if [ "${{ vars.SONATYPE_OSS_INDEX }}" == "OFF" ]; then
+            echo "analyzer.ossindex.enabled=false" > dependency-check.properties
+          else
+            echo "analyzer.ossindex.password=${{ secrets.OSS_INDEX_PASSWORD }}" > dependency-check.properties
+          fi
           ls -l
           cat dependency-check.properties
 
       # Perform SCA Scan
       - name: Perform SCA Scan
         if: ${{ !contains(matrix.version, 'maintenance') || vars.MAINTENANCE_CI != 'OFF' }}
-        run: ./dependency-check/bin/dependency-check.sh --project="WildFly ${{ matrix.version}}" --scan="wildfly" --noupdate --suppression=owasp-suppressions/owasp-suppressions.xml --data=owasp-database --format=HTML --format=JSON --nvdApiKey=${{ secrets.NVD_API_KEY }} --ossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} --propertyfile=dependency-check.properties --log=dependency-check.log
+        run: |
+          OSS_ARGS=""
+          if [ "${{ vars.SONATYPE_OSS_INDEX }}" != "OFF" ]; then
+            OSS_ARGS="--ossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }}"
+          fi
+          ./dependency-check/bin/dependency-check.sh --project="WildFly ${{ matrix.version}}" --scan="wildfly" --noupdate --suppression=owasp-suppressions/owasp-suppressions.xml --data=owasp-database --format=HTML --format=JSON --nvdApiKey=${{ secrets.NVD_API_KEY }} $OSS_ARGS --propertyfile=dependency-check.properties --log=dependency-check.log
 
       # Upload the log files
       - name: Upload Scan Results


### PR DESCRIPTION
When the repository variable SONATYPE_OSS_INDEX is set to 'OFF', the OSS Index analyzer is disabled in both the database maintenance and scan workflows, preventing 402 Payment Required failures from Sonatype.