### PR TITLE
Resolves #70 Suppress CVE-2026-2586 and CVE-2026-2587 against relaxng-datatype and rngom

### DIFF
--- a/owasp-suppressions/owasp-suppressions.xml
+++ b/owasp-suppressions/owasp-suppressions.xml
@@ -522,24 +522,31 @@
     <cve>CVE-2026-34479</cve>
     <cve>CVE-2026-34477</cve>
   </suppress>
-  <suppress until="2027-05-20">
+  <suppress until="2027-06-08">
     <notes><![CDATA[
     file names: relaxng-datatype-4.0.8.jar, rngom-4.0.8.jar
 
-    [Issue #65] These are JAXB XML schema parsing libraries (com.sun.xml.bind.external groupId)
+    [Issue #65] [Issue #70] These are JAXB XML schema parsing libraries (com.sun.xml.bind.external groupId)
     being incorrectly matched to the Eclipse GlassFish application server CPE due to two coinciding
-    factors: (a) shared GlassFish/JAXB-RI project heritage, and (b) version number coincidence
-    (library v4.0.8 vs. GlassFish application server 4.0.8).
+    factors: (a) shared GlassFish/JAXB-RI project heritage causing the scanner to assign
+    cpe:2.3:a:eclipse:glassfish via the parent groupId org.glassfish.jaxb, and (b) version number
+    coincidence (library v4.0.8 vs. GlassFish application server 4.0.8).
 
-    CVE-2024-9329 is an open redirect vulnerability in the GlassFish /management/domain HTTP
-    management endpoint. These libraries are pure XML parsing components with no HTTP server,
-    management API, or redirect functionality. The actually vulnerable component is
-    org.glassfish.main.admin:rest-service, which is not present in WildFly.
+    These libraries are pure XML parsing components with no HTTP server, admin console, or EL
+    evaluation functionality. The actually vulnerable components are exclusively in the GlassFish
+    Administration Console (org.glassfish.main.admingui:console-common), which is not present
+    in WildFly:
+    - CVE-2024-9329: open redirect in the GlassFish /management/domain HTTP management endpoint
+    - CVE-2026-2586: authenticated RCE via crafted requests to the GlassFish admin console
+    - CVE-2026-2587: unauthenticated EL injection via the GlassFish gadget handler (gadget.jsf)
 
     https://github.com/wildfly-security/wildfly-sca-scanner/issues/65
+    https://github.com/wildfly-security/wildfly-sca-scanner/issues/70
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.sun\.xml\.bind\.external/(relaxng-datatype|rngom)@.*$</packageUrl>
     <cve>CVE-2024-9329</cve>
+    <cve>CVE-2026-2586</cve>
+    <cve>CVE-2026-2587</cve>
   </suppress>
   <suppress until="2027-05-20">
     <notes><![CDATA[

--- a/owasp-suppressions/owasp-suppressions.xml
+++ b/owasp-suppressions/owasp-suppressions.xml
@@ -571,4 +571,25 @@
     <filePath regex="true">^.*/wildfly/bin/client/jboss-client\.jar$</filePath>
     <cve>CVE-2026-42582</cve>
   </suppress>
+  <suppress until="2027-06-08">
+    <notes><![CDATA[
+    file names: cxf-core-4.0.11.jar, cxf-rt-databinding-aegis-4.0.11.jar,
+    cxf-rt-features-clustering-4.0.11.jar, cxf-rt-ws-security-4.0.11.jar,
+    cxf-services-sts-core-4.0.11.jar, cxf-tools-wsdlto-core-4.0.11.jar
+
+    [Issue #68] These CVEs affect CXF sub-modules that are not present in WildFly:
+    - CVE-2026-44930: LDAP injection in the LDAP Certificate repository of the CXF XKMS server
+      (cxf-services-xkms-* modules). WildFly does not ship the CXF XKMS server.
+    - CVE-2026-44618: Insecure XML parser configuration in CXF's WS-Transfer module
+      (cxf-rt-ws-transfer). WildFly does not ship the CXF WS-Transfer module.
+
+    The scanner attributes these CVEs to all CXF jars at version 4.0.11 via a product-level
+    match, but the actually vulnerable components are absent from the WildFly distribution.
+
+    https://github.com/wildfly-security/wildfly-sca-scanner/issues/68
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.cxf[^/]*/.*@.*$</packageUrl>
+    <cve>CVE-2026-44930</cve>
+    <cve>CVE-2026-44618</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Both CVEs affect org.glassfish.main.admingui:console-common (the GlassFish
admin console), not the JAXB XML schema parsing libraries flagged by the
scanner. The match is the same CPE mis-assignment as CVE-2024-9329 — the
org.glassfish.jaxb parent groupId causes the scanner to assign the
cpe:2.3:a:eclipse:glassfish CPE, and library version 4.0.8 satisfies
versionEndExcluding:8.0.2 for all three GlassFish CVEs. Updated the
existing Issue #65 suppression block to add the two new CVE IDs and
refreshed the until date to 2027-06-08.